### PR TITLE
接続切断後のプリセット保存/削除ボタンの状態を修正する

### DIFF
--- a/lib/bcdice-irc/gui/application.rb
+++ b/lib/bcdice-irc/gui/application.rb
@@ -489,6 +489,7 @@ module BCDiceIRC
       def setup_state_observers
         @state.add_observers(
           Observers::State.main_window_title(self),
+          Observers::State.preset_store_view_model(@preset_store_vm),
           Observers::State.general_widgets(@widget_set),
           Observers::State.widgets_for_password(w.password_check_button, self),
           Observers::State.connect_disconnect_button(w.connect_disconnect_button),

--- a/lib/bcdice-irc/gui/observers/state.rb
+++ b/lib/bcdice-irc/gui/observers/state.rb
@@ -16,14 +16,21 @@ module BCDiceIRC
           end
         end
 
+        # プリセット集のビューモデルのオブザーバを返す
+        # @param [PresetStoreViewModel] preset_store_vm
+        # @return [Proc]
+        def preset_store_view_model(preset_store_vm)
+          lambda do |state|
+            preset_store_vm.sensitive = state.general_widgets_sensitive
+          end
+        end
+
         # IRCボット設定の一般的なウィジェットのオブザーバを返す
         # @param [WidgetSet] widget_set ウィジェット集
         # @return [Proc]
         def general_widgets(widget_set)
           widgets = [
             widget_set.preset_combo_box,
-            widget_set.preset_save_button,
-            widget_set.preset_delete_button,
 
             widget_set.hostname_entry,
             widget_set.port_spin_button,

--- a/test/gui/preset_store_view_model_test.rb
+++ b/test/gui/preset_store_view_model_test.rb
@@ -275,6 +275,49 @@ module BCDiceIRC
         assert_nil(preset_index)
         assert_nil(preset_name)
       end
+
+      test '#sensitive= should correctly update preset_save_action and preset_deletability' do
+        @store.push(@config1)
+        @store.push(@config2)
+        @store.index_last_selected = 1
+
+        preset_save_button_sensitive = nil
+        preset_delete_button_sensitive = nil
+
+        @view_model.add_preset_save_action_updated_handlers(
+          ->action { preset_save_button_sensitive = action != :none }
+        )
+
+        @view_model.add_preset_deletability_updated_handlers(
+          ->can_delete_preset { preset_delete_button_sensitive = can_delete_preset }
+        )
+
+        @view_model.sensitive = true
+
+        @view_model.temporary_preset_name = 'Config 1'
+        assert_true(preset_save_button_sensitive)
+        assert_true(preset_delete_button_sensitive)
+
+        @view_model.temporary_preset_name = 'Config 2'
+        assert_true(preset_save_button_sensitive)
+        assert_false(preset_delete_button_sensitive)
+
+        @view_model.sensitive = false
+        assert_false(preset_save_button_sensitive)
+        assert_false(preset_delete_button_sensitive)
+
+        @view_model.temporary_preset_name = 'Config 1'
+        assert_false(preset_save_button_sensitive)
+        assert_false(preset_delete_button_sensitive)
+
+        @view_model.sensitive = true
+        assert_true(preset_save_button_sensitive)
+        assert_true(preset_delete_button_sensitive)
+
+        @view_model.temporary_preset_name = 'Config 2'
+        assert_true(preset_save_button_sensitive)
+        assert_false(preset_delete_button_sensitive)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #24

接続切断後にプリセット保存/削除ボタンが不正な状態になっていた問題を修正する。